### PR TITLE
Fix shopping list delete dialog styling

### DIFF
--- a/app/src/main/java/com/wbpxre150/shoppinglist/ShoppingListDetailActivity.kt
+++ b/app/src/main/java/com/wbpxre150/shoppinglist/ShoppingListDetailActivity.kt
@@ -635,43 +635,37 @@ class ShoppingListDetailActivity : AppCompatActivity() {
     }
 
     private fun showDeleteConfirmationDialog() {
+        val dialogView = layoutInflater.inflate(R.layout.dialog_delete_confirmation, null)
+        val buttonCancel = dialogView.findViewById<Button>(R.id.buttonCancel)
+        val buttonDelete = dialogView.findViewById<Button>(R.id.buttonDelete)
+
         val dialog = AlertDialog.Builder(this)
-            .setTitle("Delete Shopping List")
-            .setMessage("Are you sure you want to delete this shopping list and all its items?")
-            .setPositiveButton("Delete") { _, _ ->
-                // Get the full ShoppingList object before deleting using one-time observation
-                val shoppingListLiveData = shoppingViewModel.getShoppingListById(listId)
-                val observer = object : androidx.lifecycle.Observer<ShoppingList?> {
-                    override fun onChanged(value: ShoppingList?) {
-                        if (value != null) {
-                            // Remove observer immediately to prevent memory leaks
-                            shoppingListLiveData.removeObserver(this)
-                            shoppingViewModel.delete(value)
-                            finish()
-                        }
-                    }
-                }
-                shoppingListLiveData.observe(this, observer)
-            }
-            .setNegativeButton("Cancel", null)
+            .setView(dialogView)
             .create()
 
-        dialog.setOnShowListener {
-            // Customize buttons with icons
-            dialog.getButton(AlertDialog.BUTTON_POSITIVE)?.apply {
-                text = ""
-                setCompoundDrawablesWithIntrinsicBounds(R.drawable.ic_confirm, 0, 0, 0)
-                compoundDrawablePadding = 0
-                contentDescription = "Delete"
-                setTextColor(getColor(R.color.dialog_confirm_green))
+        // Set transparent background for MaterialCardView styling
+        dialog.window?.setBackgroundDrawableResource(android.R.color.transparent)
+
+        // Set up button listeners
+        buttonCancel.setOnClickListener {
+            dialog.dismiss()
+        }
+
+        buttonDelete.setOnClickListener {
+            // Get the full ShoppingList object before deleting using one-time observation
+            val shoppingListLiveData = shoppingViewModel.getShoppingListById(listId)
+            val observer = object : androidx.lifecycle.Observer<ShoppingList?> {
+                override fun onChanged(value: ShoppingList?) {
+                    if (value != null) {
+                        // Remove observer immediately to prevent memory leaks
+                        shoppingListLiveData.removeObserver(this)
+                        shoppingViewModel.delete(value)
+                        finish()
+                    }
+                }
             }
-            dialog.getButton(AlertDialog.BUTTON_NEGATIVE)?.apply {
-                text = ""
-                setCompoundDrawablesWithIntrinsicBounds(R.drawable.ic_cancel, 0, 0, 0)
-                compoundDrawablePadding = 0
-                contentDescription = "Cancel"
-                setTextColor(getColor(R.color.dialog_cancel_red))
-            }
+            shoppingListLiveData.observe(this, observer)
+            dialog.dismiss()
         }
 
         dialog.show()
@@ -710,71 +704,59 @@ class ShoppingListDetailActivity : AppCompatActivity() {
     }
 
     private fun showPermissionExplanationDialog() {
+        val dialogView = layoutInflater.inflate(R.layout.dialog_permission_notification, null)
+        val buttonCancel = dialogView.findViewById<Button>(R.id.buttonCancel)
+        val buttonGrantPermission = dialogView.findViewById<Button>(R.id.buttonGrantPermission)
+
         val dialog = AlertDialog.Builder(this)
-            .setTitle("Notification Permission Required")
-            .setMessage("This app needs notification permission to remind you about your shopping items. Please grant the permission to enable reminders.")
-            .setPositiveButton("Grant Permission") { _, _ ->
-                ActivityCompat.requestPermissions(
-                    this,
-                    arrayOf(Manifest.permission.POST_NOTIFICATIONS),
-                    REQUEST_NOTIFICATION_PERMISSION
-                )
-            }
-            .setNegativeButton("Cancel", null)
+            .setView(dialogView)
             .create()
 
-        dialog.setOnShowListener {
-            // Customize buttons with icons
-            dialog.getButton(AlertDialog.BUTTON_POSITIVE)?.apply {
-                text = ""
-                setCompoundDrawablesWithIntrinsicBounds(R.drawable.ic_confirm, 0, 0, 0)
-                compoundDrawablePadding = 0
-                contentDescription = "Grant Permission"
-                setTextColor(getColor(R.color.dialog_confirm_green))
-            }
-            dialog.getButton(AlertDialog.BUTTON_NEGATIVE)?.apply {
-                text = ""
-                setCompoundDrawablesWithIntrinsicBounds(R.drawable.ic_cancel, 0, 0, 0)
-                compoundDrawablePadding = 0
-                contentDescription = "Cancel"
-                setTextColor(getColor(R.color.dialog_cancel_red))
-            }
+        // Set transparent background for MaterialCardView styling
+        dialog.window?.setBackgroundDrawableResource(android.R.color.transparent)
+
+        // Set up button listeners
+        buttonCancel.setOnClickListener {
+            dialog.dismiss()
+        }
+
+        buttonGrantPermission.setOnClickListener {
+            ActivityCompat.requestPermissions(
+                this,
+                arrayOf(Manifest.permission.POST_NOTIFICATIONS),
+                REQUEST_NOTIFICATION_PERMISSION
+            )
+            dialog.dismiss()
         }
 
         dialog.show()
     }
 
     private fun showExactAlarmPermissionDialog() {
+        val dialogView = layoutInflater.inflate(R.layout.dialog_permission_alarm, null)
+        val buttonCancel = dialogView.findViewById<Button>(R.id.buttonCancel)
+        val buttonOpenSettings = dialogView.findViewById<Button>(R.id.buttonOpenSettings)
+
         val dialog = AlertDialog.Builder(this)
-            .setTitle("Exact Alarm Permission Required")
-            .setMessage("This app needs permission to schedule exact alarms for precise reminders. Please enable this in Settings.")
-            .setPositiveButton("Open Settings") { _, _ ->
-                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
-                    val intent = Intent(Settings.ACTION_REQUEST_SCHEDULE_EXACT_ALARM).apply {
-                        data = Uri.parse("package:$packageName")
-                    }
-                    startActivity(intent)
-                }
-            }
-            .setNegativeButton("Cancel", null)
+            .setView(dialogView)
             .create()
 
-        dialog.setOnShowListener {
-            // Customize buttons with icons
-            dialog.getButton(AlertDialog.BUTTON_POSITIVE)?.apply {
-                text = ""
-                setCompoundDrawablesWithIntrinsicBounds(R.drawable.ic_confirm, 0, 0, 0)
-                compoundDrawablePadding = 0
-                contentDescription = "Open Settings"
-                setTextColor(getColor(R.color.dialog_confirm_green))
+        // Set transparent background for MaterialCardView styling
+        dialog.window?.setBackgroundDrawableResource(android.R.color.transparent)
+
+        // Set up button listeners
+        buttonCancel.setOnClickListener {
+            dialog.dismiss()
+        }
+
+        buttonOpenSettings.setOnClickListener {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+                val intent = Intent(Settings.ACTION_REQUEST_SCHEDULE_EXACT_ALARM).apply {
+                    data = Uri.parse("package:$packageName")
+                }
+                startActivity(intent)
             }
-            dialog.getButton(AlertDialog.BUTTON_NEGATIVE)?.apply {
-                text = ""
-                setCompoundDrawablesWithIntrinsicBounds(R.drawable.ic_cancel, 0, 0, 0)
-                compoundDrawablePadding = 0
-                contentDescription = "Cancel"
-                setTextColor(getColor(R.color.dialog_cancel_red))
-            }
+            dialog.dismiss()
         }
 
         dialog.show()

--- a/app/src/main/res/layout/dialog_delete_confirmation.xml
+++ b/app/src/main/res/layout/dialog_delete_confirmation.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="utf-8"?>
+<com.google.android.material.card.MaterialCardView
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    app:cardCornerRadius="@dimen/dialog_corner_radius"
+    app:cardElevation="@dimen/dialog_elevation"
+    app:strokeWidth="@dimen/dialog_stroke_width"
+    app:strokeColor="?attr/colorOutlineVariant"
+    android:backgroundTint="?attr/colorSurfaceContainer"
+    app:cardPreventCornerOverlap="true">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        android:padding="@dimen/dialog_content_padding">
+
+        <TextView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="@string/delete_shopping_list"
+            android:textSize="18sp"
+            android:textStyle="bold"
+            android:layout_marginBottom="16dp" />
+
+        <TextView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="@string/delete_confirmation_message"
+            android:textSize="14sp"
+            android:layout_marginBottom="16dp" />
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal"
+            android:gravity="end">
+
+            <com.google.android.material.button.MaterialButton
+                android:id="@+id/buttonCancel"
+                android:layout_width="48dp"
+                android:layout_height="48dp"
+                style="@style/Widget.ShoppingList.DialogIconButton.Cancel"
+                android:layout_marginEnd="8dp" />
+
+            <com.google.android.material.button.MaterialButton
+                android:id="@+id/buttonDelete"
+                android:layout_width="48dp"
+                android:layout_height="48dp"
+                style="@style/Widget.ShoppingList.DialogIconButton.Confirm" />
+        </LinearLayout>
+
+    </LinearLayout>
+
+</com.google.android.material.card.MaterialCardView>

--- a/app/src/main/res/layout/dialog_permission_alarm.xml
+++ b/app/src/main/res/layout/dialog_permission_alarm.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="utf-8"?>
+<com.google.android.material.card.MaterialCardView
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res/auto"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    app:cardCornerRadius="@dimen/dialog_corner_radius"
+    app:cardElevation="@dimen/dialog_elevation"
+    app:strokeWidth="@dimen/dialog_stroke_width"
+    app:strokeColor="?attr/colorOutlineVariant"
+    android:backgroundTint="?attr/colorSurfaceContainer"
+    app:cardPreventCornerOverlap="true">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        android:padding="@dimen/dialog_content_padding">
+
+        <TextView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="@string/exact_alarm_permission_title"
+            android:textSize="18sp"
+            android:textStyle="bold"
+            android:layout_marginBottom="16dp" />
+
+        <TextView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="@string/exact_alarm_permission_message"
+            android:textSize="14sp"
+            android:layout_marginBottom="16dp" />
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal"
+            android:gravity="end">
+
+            <com.google.android.material.button.MaterialButton
+                android:id="@+id/buttonCancel"
+                android:layout_width="48dp"
+                android:layout_height="48dp"
+                style="@style/Widget.ShoppingList.DialogIconButton.Cancel"
+                android:layout_marginEnd="8dp" />
+
+            <com.google.android.material.button.MaterialButton
+                android:id="@+id/buttonOpenSettings"
+                android:layout_width="48dp"
+                android:layout_height="48dp"
+                style="@style/Widget.ShoppingList.DialogIconButton.Confirm" />
+        </LinearLayout>
+
+    </LinearLayout>
+
+</com.google.android.material.card.MaterialCardView>

--- a/app/src/main/res/layout/dialog_permission_notification.xml
+++ b/app/src/main/res/layout/dialog_permission_notification.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="utf-8"?>
+<com.google.android.material.card.MaterialCardView
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    app:cardCornerRadius="@dimen/dialog_corner_radius"
+    app:cardElevation="@dimen/dialog_elevation"
+    app:strokeWidth="@dimen/dialog_stroke_width"
+    app:strokeColor="?attr/colorOutlineVariant"
+    android:backgroundTint="?attr/colorSurfaceContainer"
+    app:cardPreventCornerOverlap="true">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        android:padding="@dimen/dialog_content_padding">
+
+        <TextView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="@string/notification_permission_title"
+            android:textSize="18sp"
+            android:textStyle="bold"
+            android:layout_marginBottom="16dp" />
+
+        <TextView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="@string/notification_permission_message"
+            android:textSize="14sp"
+            android:layout_marginBottom="16dp" />
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal"
+            android:gravity="end">
+
+            <com.google.android.material.button.MaterialButton
+                android:id="@+id/buttonCancel"
+                android:layout_width="48dp"
+                android:layout_height="48dp"
+                style="@style/Widget.ShoppingList.DialogIconButton.Cancel"
+                android:layout_marginEnd="8dp" />
+
+            <com.google.android.material.button.MaterialButton
+                android:id="@+id/buttonGrantPermission"
+                android:layout_width="48dp"
+                android:layout_height="48dp"
+                style="@style/Widget.ShoppingList.DialogIconButton.Confirm" />
+        </LinearLayout>
+
+    </LinearLayout>
+
+</com.google.android.material.card.MaterialCardView>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -35,4 +35,10 @@
     <string name="set_reminder">Set Reminder</string>
     <string name="reminder_past_error">Cannot set reminder in the past</string>
     <string name="reminder_set">Reminder set successfully</string>
+    <string name="delete_shopping_list">Delete Shopping List</string>
+    <string name="delete_confirmation_message">Are you sure you want to delete this shopping list and all its items?</string>
+    <string name="notification_permission_title">Notification Permission Required</string>
+    <string name="notification_permission_message">This app needs notification permission to remind you about your shopping items. Please grant the permission to enable reminders.</string>
+    <string name="exact_alarm_permission_title">Exact Alarm Permission Required</string>
+    <string name="exact_alarm_permission_message">This app needs permission to schedule exact alarms for precise reminders. Please enable this in Settings.</string>
 </resources>


### PR DESCRIPTION
This commit fixes the theming inconsistencies in the delete shopping list dialog and two permission dialogs by converting them from programmatic button customization to MaterialCardView-based custom layouts, matching the theme of all other dialogs in the app.

Changes:
- Created 3 new dialog layout files using MaterialCardView with proper theme attributes
  - dialog_delete_confirmation.xml
  - dialog_permission_notification.xml
  - dialog_permission_alarm.xml
- Refactored 3 dialog functions in ShoppingListDetailActivity.kt to use custom layouts
  - showDeleteConfirmationDialog()
  - showPermissionExplanationDialog()
  - showExactAlarmPermissionDialog()
- Added 6 new string resources for dialog titles and messages
- Set transparent dialog backgrounds for MaterialCardView styling
- Applied predefined MaterialButton styles for consistent icon colors

Result:
All dialogs now have consistent theming with proper background colors, card elevation, themed outline strokes, and correctly colored icons (green tick and red cross) matching the Material Design 3 theme.